### PR TITLE
Squash an Express deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (opts = {}) {
       (req.header('X-Forwarded-Proto') || req.protocol) !== 'https' ||
       req.header('Host') !== opts.host
     ) {
-      return res.redirect('https://' + opts.host + req.path, opts.statusCode);
+      return res.redirect(opts.statusCode, 'https://' + opts.host + req.path);
     }
     next();
   };


### PR DESCRIPTION
Specifically:

    express deprecated res.redirect(url, status): Use res.redirect(status, url) instead node_modules/@ryanburnette/express-force-canonical/index.js:16:18

I manually tested this.